### PR TITLE
allow previously loaded larger images to be used at lower media sizes

### DIFF
--- a/js/picturefill-dev.js
+++ b/js/picturefill-dev.js
@@ -18,8 +18,8 @@
         // See if which sources match
         for( var j = 0, jl = sources.length; j < jl; j++ ){
           var media = sources[ j ].getAttribute( "data-media" );
-          // if there's no media specified, OR w.matchMedia is supported 
-          if( !media || ( w.matchMedia && w.matchMedia( media ).matches ) ){
+          // if there's no media specified, OR w.matchMedia is supported OR media has already been loaded
+          if( !media || ( w.matchMedia && w.matchMedia( media ).matches ) || ( sources[ j ].getAttribute("data-loaded") !== null) ){
             matches.push( sources[ j ] );
           }
         }
@@ -40,6 +40,7 @@
 
         picImg.src =  matchedEl.getAttribute( "data-src" );
         matchedEl.appendChild( picImg );
+        matchedEl.setAttribute("data-loaded", "true");
         picImg.removeAttribute("width");
         picImg.removeAttribute("height");
       }


### PR DESCRIPTION
Marks sources that have already been loaded using a data attribute, then includes these "cached" sources in the list of matches. This prevents the script from loading a new image if a larger one has already been used.

Saw this comment and figured I'd take a crack at it: http://css-tricks.com/hassle-free-responsive-images-for-wordpress/#li-comment-1513380
