### PR TITLE
Prefix functions, space usage, add_sizes via hook

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -64,7 +64,7 @@ function tevkori_responsive_shortcode( $atts ) {
 		</span>';
 }
 // TODO: It this the best name? responsive_img? picture?
-add_shortcode( 'responsive', 'responsive_shortcode' );
+add_shortcode( 'responsive', 'tevkori_responsive_shortcode' );
 
 // Alter Media Uploader output to output shortcode instead
 // TODO: Make optional?


### PR DESCRIPTION
Some small tweaks:
- Function names are prefixed with `tevkori_` to [prevent conflicts](http://nacin.com/2010/05/11/in-wordpress-prefix-everything/).
- Added whitespace to better conform with the [WP coding standards](http://make.wordpress.org/core/handbook/coding-standards/php/#space-usage).
- Additional image sizes are added via a function which loads on the ‘plugins_loaded' hook.
- Removed [closing php](http://make.wordpress.org/core/handbook/coding-standards/php/#remove-trailing-spaces) tag.
