### PR TITLE
Remove ‘post-thumbnails’ prerequisite from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,14 +20,6 @@ This plugin tells WordPress to create three additional sizes for images you uplo
 	   	<noscript> <?php echo wp_get_attachment_image($imageid, $mappings[2]) ?> </noscript>
 	</span>
 
-### Prereqs
-
-Make sure your current theme has
-
-    'add_theme_support( 'post-thumbnails' );'
-
-in the `functions.php` file.
-
 ### Tutorial
 
 Here: http://css-tricks.com/hassle-free-responsive-images-for-wordpress


### PR DESCRIPTION
The [Codex page](http://codex.wordpress.org/Function_Reference/add_image_size) for the `add_image_size` function is incorrect. To add additional image sizes there is no need for the theme to explicitly support post-thumbnails.

Note: In the meantime I fixed the Codex article.
